### PR TITLE
Simplify some of the names in clone_merge

### DIFF
--- a/legion-prefab/src/cooking.rs
+++ b/legion-prefab/src/cooking.rs
@@ -1,7 +1,7 @@
 use legion::*;
 use legion::storage::ComponentTypeId;
 use std::collections::HashMap;
-use crate::{CookedPrefab, Prefab, ComponentRegistration, CopyCloneImpl};
+use crate::{CookedPrefab, Prefab, ComponentRegistration, CopyClone};
 use prefab_format::{PrefabUuid, ComponentTypeUuid};
 use std::hash::BuildHasher;
 
@@ -22,7 +22,7 @@ pub fn cook_prefab<S: BuildHasher, T: BuildHasher, U: BuildHasher>(
     for prefab in prefab_lookup.values() {
         // Create the clone_merge impl. For prefab cooking, we will clone everything so we don't need to
         // set up any transformations
-        let mut clone_merge_impl = CopyCloneImpl::new(registered_components);
+        let mut clone_merge_impl = CopyClone::new(registered_components);
 
         // Clone all the entities from the prefab into the cooked world.
         let result_mappings =

--- a/legion-prefab/src/lib.rs
+++ b/legion-prefab/src/lib.rs
@@ -27,8 +27,8 @@ pub use cooking::cook_prefab;
 // Implements a safer, easier to use layer on top of legion's clone_from and clone_from_single by
 // using the type registry in legion-prefab
 mod clone_merge;
-pub use clone_merge::CopyCloneImpl;
-pub use clone_merge::SpawnCloneImpl;
-pub use clone_merge::SpawnCloneImplHandlerSet;
+pub use clone_merge::CopyClone;
+pub use clone_merge::SpawnClone;
+pub use clone_merge::SpawnCloneHandlerSet;
 pub use clone_merge::SpawnFrom;
 pub use clone_merge::SpawnInto;

--- a/legion-prefab/src/prefab_builder.rs
+++ b/legion-prefab/src/prefab_builder.rs
@@ -3,7 +3,7 @@ use prefab_format::{EntityUuid, ComponentTypeUuid, PrefabUuid};
 
 use std::collections::HashMap;
 use crate::{ComponentRegistration, DiffSingleResult, ComponentOverride, PrefabMeta, PrefabRef};
-use crate::{CookedPrefab, CopyCloneImpl, Prefab};
+use crate::{CookedPrefab, CopyClone, Prefab};
 use fnv::FnvHashMap;
 use std::hash::BuildHasher;
 
@@ -57,7 +57,7 @@ impl PrefabBuilder {
     pub fn new<S: BuildHasher>(
         prefab_uuid: PrefabUuid,
         prefab: CookedPrefab,
-        mut clone_impl: CopyCloneImpl<S>,
+        mut clone_impl: CopyClone<S>,
     ) -> Self {
         let mut before_world = World::default();
         let before_result_mappings =
@@ -100,7 +100,7 @@ impl PrefabBuilder {
     pub fn create_prefab<S: BuildHasher>(
         &mut self,
         registered_components: &HashMap<ComponentTypeUuid, ComponentRegistration>,
-        mut clone_impl: CopyCloneImpl<S>,
+        mut clone_impl: CopyClone<S>,
     ) -> Result<Prefab, PrefabBuilderError> {
         let mut new_prefab_world = World::default();
         let mut new_prefab_entities = HashMap::new();

--- a/legion-transaction/src/component_diffs.rs
+++ b/legion-transaction/src/component_diffs.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use legion::*;
 use legion_prefab::DiffSingleResult;
 use legion_prefab::ComponentRegistration;
-use legion_prefab::CopyCloneImpl;
+use legion_prefab::CopyClone;
 use std::hash::BuildHasher;
 
 #[derive(Clone, Debug)]
@@ -145,7 +145,7 @@ pub fn apply_diff_to_prefab<S: BuildHasher, T: BuildHasher>(
     prefab: &Prefab,
     diff: &WorldDiff,
     registered_components: &HashMap<ComponentTypeUuid, ComponentRegistration, T>,
-    clone_impl: CopyCloneImpl<S>,
+    clone_impl: CopyClone<S>,
 ) -> Result<Prefab, ApplyDiffToPrefabError> {
     if !prefab.prefab_meta.prefab_refs.is_empty() {
         return Err(ApplyDiffToPrefabError::PrefabHasOverrides);
@@ -176,7 +176,7 @@ pub fn apply_diff_to_cooked_prefab<S: BuildHasher, T: BuildHasher>(
     cooked_prefab: &CookedPrefab,
     diff: &WorldDiff,
     registered_components: &HashMap<ComponentTypeUuid, ComponentRegistration, T>,
-    clone_impl: CopyCloneImpl<S>,
+    clone_impl: CopyClone<S>,
 ) -> CookedPrefab {
     let (new_world, uuid_to_new_entities) = apply_diff(
         &cooked_prefab.world,
@@ -197,7 +197,7 @@ pub fn apply_diff<S: BuildHasher, U: BuildHasher, T: BuildHasher>(
     uuid_to_entity: &HashMap<EntityUuid, Entity, T>,
     diff: &WorldDiff,
     registered_components: &HashMap<ComponentTypeUuid, ComponentRegistration, U>,
-    mut clone_impl: CopyCloneImpl<S>,
+    mut clone_impl: CopyClone<S>,
 ) -> (World, HashMap<EntityUuid, Entity>) {
     // Create an empty world to populate
     let mut new_world = World::default();

--- a/legion-transaction/src/transactions.rs
+++ b/legion-transaction/src/transactions.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use legion_prefab::{ComponentRegistration, DiffSingleResult};
 use crate::component_diffs::{ComponentDiff, EntityDiff, EntityDiffOp, WorldDiff};
-use legion_prefab::CopyCloneImpl;
+use legion_prefab::CopyClone;
 use std::hash::BuildHasher;
 
 struct TransactionBuilderEntityInfo {
@@ -38,7 +38,7 @@ impl TransactionBuilder {
     pub fn begin<S: BuildHasher>(
         self,
         src_world: &World,
-        mut clone_impl: CopyCloneImpl<S>,
+        mut clone_impl: CopyClone<S>,
     ) -> Transaction {
         let mut before_world = World::default();
         let mut after_world = World::default();


### PR DESCRIPTION
This removes all the excessive "impl"s from some of the names. This makes it a little neater and easier to understand IMO.